### PR TITLE
fix: transmit "is portal" flag into access token

### DIFF
--- a/oasis-webapp/src/main/java/oasis/services/authn/TokenHandler.java
+++ b/oasis-webapp/src/main/java/oasis/services/authn/TokenHandler.java
@@ -136,6 +136,7 @@ public class TokenHandler {
     accessToken.setScopeIds(authorizationCode.getScopeIds());
     accessToken.setClaimNames(authorizationCode.getClaimNames());
     accessToken.setServiceProviderId(authorizationCode.getServiceProviderId());
+    accessToken.setPortal(authorizationCode.isPortal());
     // Note: store the authorizationCode ID although it's been revoked to be able to
     // detect code reuse, and revoke all previously issued tokens based on the reused code.
     // (see http://tools.ietf.org/html/rfc6749#section-4.1.2)


### PR DESCRIPTION
When calling some (most of) kernel endpoints (eg the one to get a user notifications : `/n/{userId}/messages`) from a portal instance other than the default one, we receive 403 errors.

For instance, when calling the notification endpoint, we are rejected here : https://github.com/ozwillo/ozwillo-kernel/blob/9c7aa88674eaa0c34beda2b8807738afc5f04c06/oasis-webapp/src/main/java/oasis/web/notifications/NotificationEndpoint.java#L114

This PR adds the "is portal" information in the access token (taken from the authorization code), so that this information can be dealt with in authorization checks.

